### PR TITLE
Fix to LeapYearPrinterTest.isLeapYearPrintsNotLeapWhen1900()

### DIFF
--- a/src/test/java/school/mjc/stage0/conditions/task5/LeapYearPrinterTest.java
+++ b/src/test/java/school/mjc/stage0/conditions/task5/LeapYearPrinterTest.java
@@ -30,6 +30,6 @@ class LeapYearPrinterTest extends BaseIOTest {
 
         leapPrinter.isLeapYear(1900);
 
-        assertOutEquals("leap\n");
+        assertOutEquals("not leap\n");
     }
 }


### PR DESCRIPTION
Correct misstype as 1900 is not leap year